### PR TITLE
Integrate API for auth and service search

### DIFF
--- a/lib/Screens/Auth/create_account.dart
+++ b/lib/Screens/Auth/create_account.dart
@@ -4,6 +4,7 @@ import 'package:get/state_manager.dart';
 import 'package:homecleaning/Components/button.dart';
 import 'package:homecleaning/Components/text_form_field.dart';
 import 'package:homecleaning/Theme/app_theme.dart';
+import 'package:homecleaning/api/api_service.dart';
 
 class CreateAccount extends StatefulWidget {
   const CreateAccount({super.key});
@@ -156,10 +157,20 @@ class _CreateAccountState extends State<CreateAccount> {
                   ),
                 ],
               ),
-              InkWell(onTap: () {
-                   Get.toNamed('/completeProfile');
-              },
-                child: AppButton(title: 'Sign Up')),
+              InkWell(
+                  onTap: () async {
+                    try {
+                      await ApiService.register(
+                        userName: textEditingControllerName.text,
+                        email: textEditingControllerEmail.text,
+                        password: textEditingControllerPassword.text,
+                      );
+                      Get.toNamed('/completeProfile');
+                    } catch (e) {
+                      Get.snackbar('Error', e.toString());
+                    }
+                  },
+                  child: AppButton(title: 'Sign Up')),
 
               Row(
                 children: [

--- a/lib/Screens/Auth/sign_in.dart
+++ b/lib/Screens/Auth/sign_in.dart
@@ -4,6 +4,7 @@ import 'package:get/instance_manager.dart';
 import 'package:homecleaning/Components/button.dart';
 import 'package:homecleaning/Components/text_form_field.dart';
 import 'package:homecleaning/Theme/app_theme.dart';
+import 'package:homecleaning/api/api_service.dart';
 
 class SignIn extends StatefulWidget {
   const SignIn({super.key});
@@ -124,8 +125,16 @@ class _SignInState extends State<SignIn> {
                   ],
                 ),
                 InkWell(
-                  onTap: () {
-                    if (formKey.currentState!.validate()) {   Get.toNamed('/start');}
+                  onTap: () async {
+                    try {
+                      await ApiService.login(
+                        userName: textEditingControllerEmail.text,
+                        password: textEditingControllerPassword.text,
+                      );
+                      Get.toNamed('/start');
+                    } catch (e) {
+                      Get.snackbar('Error', e.toString());
+                    }
                   },
                   child: AppButton(title: 'Sign In'),
                 ),

--- a/lib/Screens/ExploreFolder/explore.dart
+++ b/lib/Screens/ExploreFolder/explore.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:homecleaning/api/api_service.dart';
 
 class Explore extends StatefulWidget {
   const Explore({super.key});
@@ -8,8 +10,64 @@ class Explore extends StatefulWidget {
 }
 
 class _ExploreState extends State<Explore> {
+  final TextEditingController _controller = TextEditingController();
+  List<Service> _services = [];
+  bool _loading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    setState(() => _loading = true);
+    try {
+      _services = await ApiService.searchServices(_controller.text);
+    } catch (e) {
+      Get.snackbar('Error', e.toString());
+    } finally {
+      setState(() => _loading = false);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
-      return Scaffold(body: Center(child: Text("Explore"),),);
+    return Scaffold(
+      appBar: AppBar(title: const Text('Services')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: _controller,
+              decoration: InputDecoration(
+                hintText: 'Search',
+                suffixIcon: IconButton(
+                  icon: const Icon(Icons.search),
+                  onPressed: _load,
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+            if (_loading) const CircularProgressIndicator(),
+            if (!_loading)
+              Expanded(
+                child: ListView.builder(
+                  itemCount: _services.length,
+                  itemBuilder: (context, index) {
+                    final s = _services[index];
+                    return ListTile(
+                      title: Text(s.name ?? 'Unnamed'),
+                      subtitle:
+                          Text(s.price != null ? '\u0024${s.price}' : ''),
+                    );
+                  },
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
   }
 }

--- a/lib/api/api_service.dart
+++ b/lib/api/api_service.dart
@@ -1,0 +1,98 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+class ApiService {
+  ApiService._();
+
+  static const String baseUrl = 'http://[::]:5000';
+  static String? token;
+
+  static Future<void> register({
+    required String userName,
+    required String email,
+    required String password,
+    String role = 'User',
+  }) async {
+    final url = Uri.parse('$baseUrl/api/Identity/register');
+    final response = await http.post(
+      url,
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode({
+        'userName': userName,
+        'email': email,
+        'password': password,
+        'role': role,
+      }),
+    );
+    if (response.statusCode != 200) {
+      throw Exception('Failed to register');
+    }
+  }
+
+  static Future<void> login({
+    required String userName,
+    required String password,
+  }) async {
+    final url = Uri.parse('$baseUrl/api/Identity/login');
+    final response = await http.post(
+      url,
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode({
+        'userName': userName,
+        'password': password,
+      }),
+    );
+    if (response.statusCode == 200) {
+      final data = jsonDecode(response.body);
+      token = data['token'] ?? data['accessToken'];
+    } else {
+      throw Exception('Failed to login');
+    }
+  }
+
+  static Future<List<Service>> searchServices(String query) async {
+    final url = Uri.parse('$baseUrl/api/Search/getservices?search=$query');
+    final response = await http.get(url, headers: {
+      if (token != null) 'Authorization': 'Bearer $token',
+    });
+    if (response.statusCode == 200) {
+      final data = jsonDecode(response.body) as List<dynamic>;
+      return data
+          .map((e) => Service.fromJson(e as Map<String, dynamic>))
+          .toList();
+    } else {
+      throw Exception('Failed to fetch services');
+    }
+  }
+}
+
+class Service {
+  final String id;
+  final String? name;
+  final String? description;
+  final double? price;
+  final String? category;
+  final String? filename;
+
+  Service({
+    required this.id,
+    this.name,
+    this.description,
+    this.price,
+    this.category,
+    this.filename,
+  });
+
+  factory Service.fromJson(Map<String, dynamic> json) {
+    return Service(
+      id: json['id']?.toString() ?? '',
+      name: json['name'],
+      description: json['description'],
+      price: json['price'] == null
+          ? null
+          : (json['price'] as num).toDouble(),
+      category: json['category'],
+      filename: json['filename'],
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   heroicons: ^0.11.0
   go_router: ^15.1.3
   get: ^4.7.2
+  http: ^1.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add http dependency
- create ApiService helper for registration, login and service search
- hook up CreateAccount and SignIn pages with the API
- implement simple search-driven service list on the Explore page

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685058e2e94c8330b140a1ca46b1c960